### PR TITLE
Add support for "rating" tag.

### DIFF
--- a/mp4tag.go
+++ b/mp4tag.go
@@ -27,6 +27,7 @@ var atomsMap = map[string]mp4.BoxType{
 	"Title":       {'\251', 'n', 'a', 'm'},
 	"Track":       {'t', 'r', 'k', 'n'},
 	"Year":        {'\251', 'd', 'a', 'y'},
+	"Rating":      {'r', 't', 'n', 'g'},
 }
 
 func copy(w *mp4.Writer, h *mp4.ReadHandle) error {
@@ -232,8 +233,14 @@ func createAndWrite(h *mp4.ReadHandle, w *mp4.Writer, ctx mp4.Context, _tags *Ta
 			return err
 		}
 	}
+	if _tags.Rating > 0 {
+		err = writeMeta(w, atomsMap["Rating"], ctx, []byte{_tags.Rating})
+		if err != nil {
+			return err
+		}
+	}
 	for tagName, needCreate := range atoms {
-		if tagName == "Cover" || tagName == "Track" || tagName == "Disk" {
+		if tagName == "Cover" || tagName == "Track" || tagName == "Disk" || tagName == "Rating" {
 			continue
 		}
 		val := reflect.ValueOf(*_tags).FieldByName(tagName).String()
@@ -319,6 +326,10 @@ func writeExisting(h *mp4.ReadHandle, w *mp4.Writer, _tags *Tags, currentKey str
 		// 	binary.BigEndian.PutUint16(trkn[4:], uint16(_tags.TrackTotal))
 		// }
 		// // err := writeMeta(w, h.BoxInfo.Type, ctx, trkn)
+	} else if currentKey == "Rating" {
+		if _tags.Rating < 1 {
+			return true, nil
+		}
 	} else {
 		toWrite := reflect.ValueOf(*_tags).FieldByName(currentKey).String()
 		if toWrite == "" {

--- a/structs.go
+++ b/structs.go
@@ -18,4 +18,5 @@ type Tags struct {
 	TrackNumber int
 	TrackTotal  int
 	Year        string
+	Rating      uint8
 }


### PR DESCRIPTION
The following code will allow for the "rating" tag to also be written.

This tag enables supported players to show a badge for explicit and clean content.

Possible values are: 0 (unrated), 1 (explicit), 2 (clean).